### PR TITLE
SEC-3052: Changed the logic to unset/delete only match token from the session instead of old tokens

### DIFF
--- a/libs/csrf/csrfprotector.php
+++ b/libs/csrf/csrfprotector.php
@@ -297,18 +297,13 @@ if (!defined('__CSRF_PROTECTOR__')) {
         private static function isValidToken($token) {
             if (!isset($_SESSION[self::$config['CSRFP_TOKEN']])) return false;
             if (!is_array($_SESSION[self::$config['CSRFP_TOKEN']])) return false;
-            foreach ($_SESSION[self::$config['CSRFP_TOKEN']] as $key => $value) {
-                if ($value == $token) {
-
-                    // Clear all older tokens assuming they have been consumed
-                    foreach ($_SESSION[self::$config['CSRFP_TOKEN']] as $_key => $_value) {
-                        if ($_value == $token) break;
-                        array_shift($_SESSION[self::$config['CSRFP_TOKEN']]);
-                    }
+            // Clear match token from the session
+            foreach ($_SESSION[self::$config['CSRFP_TOKEN']] as $_key => $_value) {
+                if ($_value == $token) {
+                    unset($_SESSION[self::$config['CSRFP_TOKEN']][$_key]);
                     return true;
                 }
             }
-
             return false;
         }
 

--- a/test/csrfprotector_test.php
+++ b/test/csrfprotector_test.php
@@ -396,7 +396,7 @@ class csrfp_test extends PHPUnit_Framework_TestCase
         $temp = $_SESSION[csrfprotector::$config['CSRFP_TOKEN']];
 
         csrfprotector::authorizePost(); //will create new session and cookies
-        $this->assertFalse($temp == $_SESSION[csrfprotector::$config['CSRFP_TOKEN']][0]);
+        $this->assertTrue(!isset($_SESSION[csrfprotector::$config['CSRFP_TOKEN']][0]));
         $this->assertTrue(csrfp_wrapper::checkHeader('Set-Cookie'));
         $this->assertTrue(csrfp_wrapper::checkHeader('csrfp_token'));
         // $this->assertTrue(csrfp_wrapper::checkHeader($_SESSION[csrfprotector::$config['CSRFP_TOKEN']][0]));  // Combine these 3 later
@@ -406,7 +406,7 @@ class csrfp_test extends PHPUnit_Framework_TestCase
         csrfp_wrapper::changeRequestType('GET');
         $_POST[csrfprotector::$config['CSRFP_TOKEN']]
             = $_GET[csrfprotector::$config['CSRFP_TOKEN']]
-            = $_SESSION[csrfprotector::$config['CSRFP_TOKEN']][0];
+            = $_SESSION[csrfprotector::$config['CSRFP_TOKEN']][1];
         $temp = $_SESSION[csrfprotector::$config['CSRFP_TOKEN']];
 
         csrfprotector::authorizePost(); //will create new session and cookies
@@ -437,7 +437,7 @@ class csrfp_test extends PHPUnit_Framework_TestCase
         $temp = $_SESSION[csrfprotector::$config['CSRFP_TOKEN']];
 
         csrfprotector::authorizePost(); //will create new session and cookies
-        $this->assertFalse($temp == $_SESSION[csrfprotector::$config['CSRFP_TOKEN']][0]);
+        $this->assertTrue(!isset($_SESSION[csrfprotector::$config['CSRFP_TOKEN']][0]));
         $this->assertTrue(csrfp_wrapper::checkHeader('Set-Cookie'));
         $this->assertTrue(csrfp_wrapper::checkHeader('csrfp_token'));
         // $this->assertTrue(csrfp_wrapper::checkHeader($_SESSION[csrfprotector::$config['CSRFP_TOKEN']][0]));  // Combine these 3 later


### PR DESCRIPTION
Changed the logic to unset/delete only match token from the session instead of old tokens